### PR TITLE
가이드라인 화면 수정

### DIFF
--- a/app/src/main/java/com/android/aviro/presentation/BindingAdapter.kt
+++ b/app/src/main/java/com/android/aviro/presentation/BindingAdapter.kt
@@ -1,16 +1,24 @@
 package com.android.aviro.presentation
 
+import android.annotation.SuppressLint
 import android.text.TextWatcher
 import android.util.Log
+import android.view.LayoutInflater
 import android.view.View
 import android.view.animation.Animation
 import android.view.animation.AnimationUtils
 import android.widget.EditText
 import androidx.core.content.ContextCompat
 import androidx.databinding.BindingAdapter
+import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentTransaction
+import androidx.viewpager2.widget.ViewPager2
 import com.android.aviro.R
+import com.android.aviro.presentation.guide.Guide
+import com.android.aviro.presentation.guide.GuideMenuFragment
+import com.android.aviro.presentation.guide.GuidePagerAdapter
+import org.jetbrains.annotations.Nullable
 
 object BindingAdapter {
 
@@ -57,6 +65,20 @@ object BindingAdapter {
         } else {
             view.background = ContextCompat.getDrawable(view.context, R.drawable.dot_guide_non)
         }
+    }
+
+    @JvmStatic
+    @BindingAdapter("app:setPageChangeListener")
+    fun ViewPager2.setPageChangeListener(pageChangeListener: ViewPager2.OnPageChangeCallback) {
+        registerOnPageChangeCallback(pageChangeListener)
+    }
+
+
+    @JvmStatic
+    @BindingAdapter("app:adapter")
+    fun adapter(view: ViewPager2, guideAdapter : GuidePagerAdapter) {
+        view.adapter = guideAdapter
+
     }
 
 }

--- a/app/src/main/java/com/android/aviro/presentation/guide/Guide.kt
+++ b/app/src/main/java/com/android/aviro/presentation/guide/Guide.kt
@@ -11,14 +11,7 @@ import com.android.aviro.databinding.ActivityGuideBinding
 class Guide : AppCompatActivity() {
 
     private lateinit var binding: ActivityGuideBinding
-    //lateinit var ViewModel: GuideViewModel
-
-    val frag1 = GuideSearchFragment()
-    val frag2 = GuideRegisterFragment()
-    val frag3 = GuideMenuFragment()
-    val frag4 = GuideReviewFragment()
-    val fragList = arrayOf(frag1, frag2, frag3, frag4)
-
+    lateinit var viewmodel: GuideViewModel
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -26,37 +19,14 @@ class Guide : AppCompatActivity() {
         binding = ActivityGuideBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
-        //ViewModel = GuideViewModel()
+        val adapter = GuidePagerAdapter(this)
 
-        binding.viewPager.adapter = adapter
+        viewmodel = GuideViewModel(adapter)
+        binding.viewmodel = viewmodel
+        binding.lifecycleOwner = this
 
-        // ViewPager에 페이지 변경 리스너 설정
-        binding.viewPager.registerOnPageChangeCallback(object : ViewPager2.OnPageChangeCallback() {
-            override fun onPageScrolled(position: Int, positionOffset: Float, positionOffsetPixels: Int) {
-                // 페이지 슬라이딩 중
-            }
 
-            override fun onPageSelected(position: Int) {
-                // 페이지 선택 시
-            }
-
-            override fun onPageScrollStateChanged(state: Int) {
-                // 페이지 스크롤 상태 변경 시
-            }
-        })
     }
 
 
-        // 뷰페이저 어댑터
-        val adapter = object : FragmentStateAdapter(this) {
-            override fun getItemCount(): Int {
-                return fragList.size
-            }
-
-            override fun createFragment(position: Int): Fragment {
-                fragList[position]
-                return fragList[position]
-            }
-        }
-
-    }
+}

--- a/app/src/main/java/com/android/aviro/presentation/guide/GuideMenuFragment.kt
+++ b/app/src/main/java/com/android/aviro/presentation/guide/GuideMenuFragment.kt
@@ -5,13 +5,17 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
 import com.android.aviro.databinding.FragmentGuideMenuBinding
+import com.android.aviro.presentation.sign.SignViewModel
 
 class GuideMenuFragment : Fragment() {
 
+    private val sharedViewModel: GuideViewModel by activityViewModels()
+
     private var _binding: FragmentGuideMenuBinding? = null
     private val binding get() = _binding!!
-    private lateinit var viewModel : GuideViewModel
+    private lateinit var viewmodel : GuideViewModel
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -21,8 +25,6 @@ class GuideMenuFragment : Fragment() {
 
         _binding = FragmentGuideMenuBinding.inflate(inflater, container, false)
         val root: View = binding.root
-
-        viewModel = GuideViewModel("menu")
 
 
         return root

--- a/app/src/main/java/com/android/aviro/presentation/guide/GuidePagerAdapter.kt
+++ b/app/src/main/java/com/android/aviro/presentation/guide/GuidePagerAdapter.kt
@@ -1,0 +1,4 @@
+package com.android.aviro.presentation.guide
+
+class GuidePagerAdapter {
+}

--- a/app/src/main/java/com/android/aviro/presentation/guide/GuidePagerAdapter.kt
+++ b/app/src/main/java/com/android/aviro/presentation/guide/GuidePagerAdapter.kt
@@ -1,4 +1,27 @@
 package com.android.aviro.presentation.guide
 
-class GuidePagerAdapter {
+import android.view.LayoutInflater
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentActivity
+import androidx.viewpager2.adapter.FragmentStateAdapter
+import com.android.aviro.R
+
+class GuidePagerAdapter(fragmentActivity : Guide) : FragmentStateAdapter(fragmentActivity)
+{
+    private val fragmentList = mutableListOf<Fragment>()
+
+    fun addFragment(fragment: Fragment) {
+        fragmentList.add(fragment)
+    }
+
+    // 어댑터가 특정 위치(position)의 Fragment 반환
+    override fun createFragment(position: Int): Fragment {
+        return fragmentList[position]
+    }
+
+    // 어댑터가 가지고 있는 Fragment 개수 반환
+    override fun getItemCount(): Int {
+        return fragmentList.size
+    }
+
 }

--- a/app/src/main/java/com/android/aviro/presentation/guide/GuideRegisterFragment.kt
+++ b/app/src/main/java/com/android/aviro/presentation/guide/GuideRegisterFragment.kt
@@ -5,13 +5,14 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
 import com.android.aviro.databinding.FragmentGuideRegisterBinding
 
 class GuideRegisterFragment : Fragment() {
 
+
     private var _binding: FragmentGuideRegisterBinding? = null
     private val binding get() = _binding!!
-    private lateinit var viewModel : GuideViewModel
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -21,8 +22,6 @@ class GuideRegisterFragment : Fragment() {
 
         _binding = FragmentGuideRegisterBinding.inflate(inflater, container, false)
         val root: View = binding.root
-
-        viewModel = GuideViewModel("register")
 
 
         return root

--- a/app/src/main/java/com/android/aviro/presentation/guide/GuideReviewFragment.kt
+++ b/app/src/main/java/com/android/aviro/presentation/guide/GuideReviewFragment.kt
@@ -6,15 +6,17 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
 import com.android.aviro.databinding.FragmentGuideReviewBinding
 import com.android.aviro.presentation.sign.Sign
 
 
 class GuideReviewFragment : Fragment() {
 
+
     private var _binding: FragmentGuideReviewBinding? = null
     private val binding get() = _binding!!
-    private lateinit var viewModel : GuideViewModel
+
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -24,8 +26,6 @@ class GuideReviewFragment : Fragment() {
 
         _binding = FragmentGuideReviewBinding.inflate(inflater, container, false)
         val root: View = binding.root
-
-        viewModel = GuideViewModel("review")
 
 
         _binding!!.startBtn.setOnClickListener {

--- a/app/src/main/java/com/android/aviro/presentation/guide/GuideSearchFragment.kt
+++ b/app/src/main/java/com/android/aviro/presentation/guide/GuideSearchFragment.kt
@@ -5,13 +5,15 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
 import com.android.aviro.databinding.FragmentGuideSearchBinding
 
 class GuideSearchFragment : Fragment() {
 
+
     private var _binding: FragmentGuideSearchBinding? = null
     private val binding get() = _binding!!
-    private lateinit var viewModel : GuideViewModel
+
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -21,8 +23,6 @@ class GuideSearchFragment : Fragment() {
 
         _binding = FragmentGuideSearchBinding.inflate(inflater, container, false)
         val root: View = binding.root
-
-        viewModel = GuideViewModel("search")
 
 
         return root

--- a/app/src/main/java/com/android/aviro/presentation/guide/GuideViewModel.kt
+++ b/app/src/main/java/com/android/aviro/presentation/guide/GuideViewModel.kt
@@ -3,22 +3,42 @@ package com.android.aviro.presentation.guide
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.viewpager2.widget.ViewPager2
 
-class GuideViewModel(fragmentId: String) : ViewModel() {
+
+class GuideViewModel(val adapter : GuidePagerAdapter) : ViewModel() {
 
     val _dot = MutableLiveData<List<Boolean>>()
     val dot : LiveData<List<Boolean>>
         get() = _dot
 
-
     init {
-        when(fragmentId) {
-            "menu" -> _dot.value = listOf(true, false, false, false)
-            "register" -> _dot.value = listOf(false, true, false, false)
-            "search" -> _dot.value = listOf(false, false, true, false)
-            "review" -> _dot.value = listOf(false, false, false, true)
-        }
+        _dot.value = listOf(true, false, false, false)
+
+        adapter.addFragment(GuideMenuFragment())
+        adapter.addFragment(GuideRegisterFragment())
+        adapter.addFragment(GuideSearchFragment())
+        adapter.addFragment(GuideReviewFragment())
 
     }
+
+    val pageCallBack = object: ViewPager2.OnPageChangeCallback() {
+        override fun onPageScrolled(position: Int, positionOffset: Float, positionOffsetPixels: Int) {
+            // 페이지 슬라이딩 중
+        }
+        override fun onPageSelected(position: Int) {
+            //super.onPageSelected(position)
+            when(position) {
+                0 -> _dot.value = listOf(true, false, false, false)
+                1 ->  _dot.value = listOf(false, true, false, false)
+                2 ->  _dot.value = listOf(false, false, true, false)
+                3 ->  _dot.value = listOf(false, false, false, true)
+            }
+        }
+        override fun onPageScrollStateChanged(state: Int) {
+            // 페이지 스크롤 상태 변경 시
+        }
+    }
+
 
 }

--- a/app/src/main/java/com/android/aviro/presentation/sign/Sign.kt
+++ b/app/src/main/java/com/android/aviro/presentation/sign/Sign.kt
@@ -36,5 +36,4 @@ class Sign : AppCompatActivity() {
     }
 
 
-
 }

--- a/app/src/main/java/com/android/aviro/presentation/sign/SignViewModel.kt
+++ b/app/src/main/java/com/android/aviro/presentation/sign/SignViewModel.kt
@@ -16,7 +16,7 @@ import java.util.regex.Pattern
 
 class SignViewModel : ViewModel() {
 
-    // 회원가입 정보를 저장할 Entity
+    // 회원가입 정보를 저장할 entity
     val userDTO = User(-1,"","","",null,null, false)
 
     // 다음으로 버튼
@@ -69,6 +69,7 @@ class SignViewModel : ViewModel() {
 
     // 닉네임 조건 확인
     fun onTextChanged(s: CharSequence, start :Int, before : Int, count: Int) {
+
         _nicknameAccountText.value = "(${s.length}/8)"
 
         if(s.length == 0) {

--- a/app/src/main/res/drawable/border2cobalt_roundsquare30white.xml
+++ b/app/src/main/res/drawable/border2cobalt_roundsquare30white.xml
@@ -1,0 +1,22 @@
+<?xmlversion="1.0"encoding="utf-8"?>
+<layer-list
+    xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+
+        <shape
+            android:shape="rectangle">
+    <stroke
+        android:width="2dp"
+        android:color="@color/Cobalt"/>
+
+        <solid
+            android:color="@color/Gray7"/>
+            <corners
+                android:bottomRightRadius="30dp"
+                android:topLeftRadius="30dp"
+                android:topRightRadius="30dp"
+                android:bottomLeftRadius="30dp" />
+        </shape>
+    </item>
+
+    </layer-list>

--- a/app/src/main/res/drawable/bottom_bar_color.xml
+++ b/app/src/main/res/drawable/bottom_bar_color.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-  
+    <!-- 상태에 따라 다른 색상을 정의합니다. -->
+    <item android:color="@color/Gray2" android:state_checked="false" android:drawable="@drawable/bottom_bar_margin"/>
+    <item android:color="@color/Cobalt" android:state_checked="true" android:drawable="@drawable/bottom_bar_margin" />
 </selector>

--- a/app/src/main/res/drawable/bottom_bar_margin.xml
+++ b/app/src/main/res/drawable/bottom_bar_margin.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<selector xmlns:android="http://schemas.android.com/apk/res/android">
-  
-</selector>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@android:color/transparent" />
+    <padding
+        android:bottom="7dp" />
+</shape>

--- a/app/src/main/res/drawable/ic_adding.xml
+++ b/app/src/main/res/drawable/ic_adding.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="25dp"
+    android:height="25dp"
+    android:viewportWidth="25"
+    android:viewportHeight="25">
+  <path
+      android:pathData="M20.5,11.357H13.643V4.5H11.357V11.357H4.5V13.643H11.357V20.5H13.643V13.643H20.5V11.357Z"
+      android:fillColor="#3173CA"/>
+</vector>

--- a/app/src/main/res/layout/activity_guide.xml
+++ b/app/src/main/res/layout/activity_guide.xml
@@ -3,10 +3,15 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
+
     <data>
         <variable
-            name="viewmodel"
-            type="com.android.aviro.presentation.guide.GuideViewModel" />
+        name="viewmodel"
+        type="com.android.aviro.presentation.guide.GuideViewModel" />
+        <variable
+            name="guideAdapter"
+            type="com.android.aviro.presentation.guide.GuidePagerAdapter" />
+
     </data>
 
 <androidx.constraintlayout.widget.ConstraintLayout
@@ -59,8 +64,9 @@
     <androidx.viewpager2.widget.ViewPager2
         android:id="@+id/viewPager"
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
-
+        android:layout_height="match_parent"
+        app:adapter="@{viewmodel.adapter}"
+        app:setPageChangeListener="@{viewmodel.pageCallBack}">
     </androidx.viewpager2.widget.ViewPager2>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_guide_menu.xml
+++ b/app/src/main/res/layout/fragment_guide_menu.xml
@@ -1,8 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
+
+<layout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:tools="http://schemas.android.com/tools">
+    <data>
+        <variable
+            name="viewmodel"
+            type="com.android.aviro.presentation.guide.GuideViewModel" />
+    </data>
+
+<androidx.constraintlayout.widget.ConstraintLayout
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -55,3 +63,4 @@
 
 
 </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/fragment_register.xml
+++ b/app/src/main/res/layout/fragment_register.xml
@@ -420,17 +420,41 @@
 
             <LinearLayout
                 android:id="@+id/aadMenuBtn"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
+                android:layout_width="match_parent"
+                android:layout_height="51dp"
+                android:layout_gravity="center"
                 android:layout_marginTop="20dp"
-                android:background="@drawable/btn_add_menu"
+                android:background="@drawable/border2cobalt_roundsquare30white"
                 android:orientation="vertical">
+                <LinearLayout
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity= "center"
+                    android:padding="10dp"
+                    android:orientation="horizontal">
+                <LinearLayout
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity= "center"
+                    android:background="@drawable/ic_adding"
+                    android:orientation="vertical">
+                </LinearLayout>
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity= "center"
+                    android:layout_marginStart="7dp"
+                    android:text="메뉴 정보 추가하기"
+                    android:textSize="16dp"
+                    android:fontFamily="@font/pretendard_semibold"
+                    android:textColor = "@color/Cobalt"/>
+
+            </LinearLayout>
             </LinearLayout>
 
-
-
-
         </LinearLayout>
+
     </LinearLayout>
     </ScrollView>
 

--- a/app/src/main/res/layout/fragment_sign_complete.xml
+++ b/app/src/main/res/layout/fragment_sign_complete.xml
@@ -28,5 +28,6 @@
         android:orientation="vertical"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"></LinearLayout>
+        app:layout_constraintStart_toStartOf="parent">
+    </LinearLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Description
===========
* 가이드라인 화면 수정
   - '점' 이미지는 액티비티에 그 외 기타 화면 이미지는 프래그먼트로 설정해 화면 이미지만 슬라이딩 되고 효과 구현
   - 뷰모델에 페이지 리스너 추가, dot 이미지 갱신을 위해 데이터바인딩 구현 (현재 페이저 위치에 따라 점 색 달라짐)
   - 기존 액티비티에 작성했던 뷰페이저 어댑터를 데이터바인딩으로 구현하기 위해 페이저 어댑터 클래스를 추가 (어댑터를 생성하기 위해서는 액티비티의 context 정보가 필요한데 이를 뷰모델에서 구현할 수 없기 때문에 어댑터 객체를 액티비티에서 생성 후 뷰모델로 넘겨줌, 뷰모델 init 할 때 어댑터 셋팅, 또한 뷰페이저에 어댑터를 설정해주는 작업도 뷰모델에서 할 수 없기 때문에 바인딩 어댑터를 사용)
  


